### PR TITLE
Refactor library into modular structure

### DIFF
--- a/src/data/BaseDataTransformer.js
+++ b/src/data/BaseDataTransformer.js
@@ -1,0 +1,84 @@
+import FormDataProcessor from "./FormDataProcessor.js";
+class BaseDataTransformer {
+    constructor(creatFormInstance) {
+        this.creatFormInstance = creatFormInstance;
+        this.processor = new FormDataProcessor(creatFormInstance);
+        this.config = creatFormInstance?.config || {};
+        this.language = this.config.language || 'fr';
+    }
+    /**
+     * Main transformation method - no more flatData!
+     */
+    transform(originalFormValues) {
+        console.log('BaseDataTransformer: Starting transformation...', {
+            originalFormValues
+        });
+        // Process form data using field configurations (same as CustomField)
+        const processedData = this.processor.processFormData(originalFormValues);
+        // Create structured format
+        return {
+            submissionType: this.getSubmissionType(),
+            formVersion: this.getFormVersion(),
+            submissionTimestamp: new Date()
+                .toISOString(),
+            language: this.language,
+            // Create sections using processed data
+            sections: this.processor.createSections(processedData),
+            // Keep processed field data for direct access
+            processedFields: processedData,
+            // Add metadata
+            metadata: this.generateMetadata(originalFormValues, processedData)
+        };
+    }
+    /**
+     * Generate metadata
+     */
+    generateMetadata(originalFormValues, processedData) {
+        return {
+            transformationTimestamp: new Date()
+                .toISOString(),
+            transformerType: this.constructor.name,
+            totalFields: Object.keys(originalFormValues)
+                .length,
+            processedFields: Object.keys(processedData)
+                .length,
+            completionPercentage: this.calculateCompletionPercentage(originalFormValues),
+            formStructure: this.determineFormStructure()
+        };
+    }
+    /**
+     * Calculate completion percentage
+     */
+    calculateCompletionPercentage(formValues) {
+        const fieldConfigs = this.processor.getFieldConfigurations();
+        const totalFields = fieldConfigs.length;
+        const completedFields = Object.keys(formValues)
+            .filter(key =>
+                this.processor.formatter.shouldDisplayValue(formValues[key])
+            )
+            .length;
+        return totalFields > 0 ? Math.round((completedFields / totalFields) * 100) : 0;
+    }
+    /**
+     * Determine form structure
+     */
+    determineFormStructure() {
+        const steps = this.creatFormInstance.formConfig?.steps?.length || 1;
+        return steps > 1 ? 'multi-step' : 'single-step';
+    }
+    /**
+     * Get submission type
+     */
+    getSubmissionType() {
+        return this.config.formType === "booking" ? "booking_form" : "submission_form";
+    }
+    /**
+     * Get form version
+     */
+    getFormVersion() {
+        return this.creatFormInstance?.defaultConfig?.FORM_VERSION || '1.0.0';
+    }
+}
+
+export default BaseDataTransformer;
+

--- a/src/data/FieldValueFormatter.js
+++ b/src/data/FieldValueFormatter.js
@@ -1,0 +1,632 @@
+// ============================================================================
+// ENHANCED FIELD VALUE FORMATTER - More robust formatting logic
+// ============================================================================
+class FieldValueFormatter {
+    constructor(creatFormInstance) {
+        this.creatFormInstance = creatFormInstance;
+        this.config = creatFormInstance?.config || {};
+        this.language = this.config.language || 'fr';
+        // Fallback translations for when the system fails
+        this.fallbackTranslations = {
+            fr: {
+                'common.yes': 'Oui',
+                'common.no': 'Non',
+                'common.other': 'Autre',
+                'common.notSpecified': 'Non spécifié',
+                'common.none': 'Aucun'
+            },
+            en: {
+                'common.yes': 'Yes',
+                'common.no': 'No',
+                'common.other': 'Other',
+                'common.notSpecified': 'Not specified',
+                'common.none': 'None'
+            }
+        };
+    }
+    /**
+     * UPDATED: Main formatting method with enhanced object handling
+     */
+    formatValue(fieldConfig, value, context = {}) {
+        if (!this.shouldDisplayValue(value)) {
+            return context.returnEmpty ? '' : this.getTranslatedText('common.notSpecified');
+        }
+        const fieldType = fieldConfig?.type;
+        try {
+            // FIX: Handle special field types first
+            if (fieldType === 'category-item-filter') {
+                return this.formatCategoryItemFilterValue(value, fieldConfig);
+            }
+            if (fieldType === 'service-request-calendar') {
+                return this.formatServiceRequestCalendarValue(value, fieldConfig);
+            }
+            // Handle complex objects with special formatting
+            if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+                return this.formatComplexObjectValue(value, fieldConfig);
+            }
+            // Regular field type handling
+            switch (fieldType) {
+            case 'yesno':
+                return this.formatYesNoValue(value, fieldConfig);
+            case 'yesno-with-options':
+                return this.formatYesNoWithOptionsValue(value, fieldConfig, context);
+            case 'select':
+            case 'select-subsections':
+                return this.formatSelectValue(value, fieldConfig);
+            case 'multiselect':
+            case 'multiselect-subsections':
+                return this.formatMultiSelectValue(value, fieldConfig);
+            case 'select-with-other':
+                return this.formatSelectWithOtherValue(value, fieldConfig);
+            case 'multiselect-with-other':
+                return this.formatMultiSelectWithOtherValue(value, fieldConfig);
+            case 'sliding-window-range':
+                return this.formatSlidingWindowRangeValue(value, fieldConfig);
+            case 'options-slider':
+                return this.formatOptionsSliderValue(value, fieldConfig);
+            case 'textarea':
+                return this.formatTextareaValue(value, context);
+            case 'email':
+            case 'phone':
+            case 'url':
+                return this.formatContactValue(value);
+            case 'number':
+            case 'percentage':
+                return this.formatNumericValue(value, fieldConfig);
+            default:
+                return this.formatDefaultValue(value);
+            }
+        } catch (error) {
+            console.error('🎨 Error formatting value:', error, {
+                fieldType,
+                value
+            });
+            return this.safeStringConversion(value);
+        }
+    }
+    /**
+     * Extract structured data for complex fields (like yesno-with-options)
+     * FIXED: No circular calls to formatValue()
+     */
+    extractStructuredValue(fieldConfig, value) {
+        if (!this.shouldDisplayValue(value)) {
+            return {
+                displayValue: '',
+                rawValue: value,
+                hasSubFields: false
+            };
+        }
+        const result = {
+            displayValue: this.formatValueDirectly(fieldConfig, value), // FIXED: Use direct formatting
+            rawValue: value,
+            hasSubFields: false,
+            subFields: {}
+        };
+        // Handle yesno-with-options specially
+        if (fieldConfig.type === 'yesno-with-options' && typeof value === 'object' && value.main !== undefined) {
+            result.mainValue = value.main;
+            result.mainDisplayValue = this.formatYesNoValue(value.main, fieldConfig);
+            result.hasSubFields = true;
+            // Determine which sub-fields to include
+            const showYesFields = this.isYesValue(value.main, fieldConfig);
+            const showNoFields = this.isNoValue(value.main, fieldConfig);
+            if (showYesFields && value.yesValues) {
+                result.subFields = this.extractSubFieldValues(
+                    fieldConfig.yesFields || (fieldConfig.yesField ? [fieldConfig.yesField] : []),
+                    value.yesValues
+                );
+            } else if (showNoFields && value.noValues) {
+                result.subFields = this.extractSubFieldValues(
+                    fieldConfig.noFields || (fieldConfig.noField ? [fieldConfig.noField] : []),
+                    value.noValues
+                );
+            }
+        }
+        return result;
+    }
+    /**
+     * Extract sub-field values for conditional fields
+     */
+    extractSubFieldValues(subFieldConfigs, subFieldValues) {
+        const extracted = {};
+        if (!Array.isArray(subFieldConfigs) || !subFieldValues) {
+            return extracted;
+        }
+        subFieldConfigs.forEach(subFieldConfig => {
+            const fieldName = subFieldConfig.name || subFieldConfig.id;
+            const fieldValue = subFieldValues[fieldName];
+            if (this.shouldDisplayValue(fieldValue)) {
+                extracted[fieldName] = {
+                    label: subFieldConfig.label,
+                    displayValue: this.formatValueDirectly(subFieldConfig, fieldValue), // FIXED: Use direct formatting
+                    rawValue: fieldValue,
+                    fieldType: subFieldConfig.type
+                };
+            }
+        });
+        return extracted;
+    }
+    // ============================================================================
+    // NEW: Direct formatting method without circular calls
+    // ============================================================================
+    /**
+     * Format value directly without calling extractStructuredValue (prevents recursion)
+     */
+    formatValueDirectly(fieldConfig, value, context = {}) {
+        if (!this.shouldDisplayValue(value)) {
+            return context.returnEmpty ? '' : this.getTranslatedText('common.notSpecified');
+        }
+        const fieldType = fieldConfig?.type;
+        try {
+            // FIX: Handle special field types first
+            if (fieldType === 'category-item-filter') {
+                return this.formatCategoryItemFilterValue(value, fieldConfig);
+            }
+            if (fieldType === 'service-request-calendar') {
+                return this.formatServiceRequestCalendarValue(value, fieldConfig);
+            }
+            switch (fieldType) {
+            case 'yesno':
+                return this.formatYesNoValue(value, fieldConfig);
+            case 'yesno-with-options':
+                // FIXED: Don't call extractStructuredValue, just format the main value
+                if (typeof value === 'object' && value.main !== undefined) {
+                    return this.formatYesNoValue(value.main, fieldConfig);
+                }
+                return this.formatYesNoValue(value, fieldConfig);
+            case 'select':
+            case 'select-subsections':
+                return this.formatSelectValue(value, fieldConfig);
+            case 'multiselect':
+            case 'multiselect-subsections':
+                return this.formatMultiSelectValue(value, fieldConfig);
+            case 'select-with-other':
+                return this.formatSelectWithOtherValue(value, fieldConfig);
+            case 'multiselect-with-other':
+                return this.formatMultiSelectWithOtherValue(value, fieldConfig);
+            case 'sliding-window-range':
+                return this.formatSlidingWindowRangeValue(value, fieldConfig);
+            case 'options-slider':
+                return this.formatOptionsSliderValue(value, fieldConfig);
+            case 'textarea':
+                return this.formatTextareaValue(value, context);
+            case 'email':
+            case 'phone':
+            case 'url':
+                return this.formatContactValue(value);
+            case 'number':
+            case 'percentage':
+                return this.formatNumericValue(value, fieldConfig);
+            default:
+                return this.formatDefaultValue(value);
+            }
+        } catch (error) {
+            console.error('🎨 Error in direct formatting:', error);
+            return this.formatDefaultValue(value);
+        }
+    }
+    // ============================================================================
+    // NEW METHODS FOR SPECIAL FIELD TYPES
+    // ============================================================================
+    /**
+     * NEW: Format CategoryItemFilterField values
+     */
+    formatCategoryItemFilterValue(value, fieldConfig) {
+        if (typeof value === 'object' && value !== null) {
+            // Handle the structured object from CategoryItemFilterField
+            if (value._separateFields) {
+                const parts = [];
+                if (value.category && String(value.category)
+                    .trim() !== '') {
+                    parts.push(String(value.category));
+                }
+                if (value.item && String(value.item)
+                    .trim() !== '') {
+                    parts.push(String(value.item));
+                }
+                return parts.join(' - ');
+            }
+            // Handle other object formats
+            if (value.selectedCategory && value.selectedItem) {
+                const itemName = value.selectedItem.displayName || value.selectedItem.name || String(value.selectedItem);
+                return `${value.selectedCategory} - ${itemName}`;
+            }
+            if (value.displayText) {
+                return String(value.displayText);
+            }
+            // Try toString method
+            if (typeof value.toString === 'function' && value.toString !== Object.prototype.toString) {
+                return value.toString();
+            }
+        }
+        return this.safeStringConversion(value);
+    }
+    /**
+     * UPDATED: Format ServiceRequestCalendar values with HTML line breaks
+     */
+    formatServiceRequestCalendarValue(value, fieldConfig) {
+        if (Array.isArray(value)) {
+            const formattedSlots = value.map(slot => {
+                if (typeof slot === 'object' && slot.displayText) {
+                    return slot.displayText;
+                }
+                if (typeof slot === 'object' && slot.date && slot.timeOfDay) {
+                    return `${slot.date} - ${slot.timeOfDay}`;
+                }
+                return this.safeStringConversion(slot);
+            });
+            // FIX: Use HTML line breaks instead of \n for proper display
+            if (formattedSlots.length > 1) {
+                return formattedSlots.map(slot => `• ${slot}`)
+                    .join('<br>');
+            } else if (formattedSlots.length === 1) {
+                return formattedSlots[0]; // Single item doesn't need bullet
+            }
+            return '';
+        }
+        return this.safeStringConversion(value);
+    }
+    /**
+     * NEW: Format complex object values
+     */
+    formatComplexObjectValue(value, fieldConfig) {
+        // Check for common display properties
+        if (value.displayText) {
+            return String(value.displayText);
+        }
+        if (value.display) {
+            return String(value.display);
+        }
+        if (value.label) {
+            return this.getLocalizedLabel(value.label);
+        }
+        if (value.name) {
+            return String(value.name);
+        }
+        if (value.value !== undefined) {
+            return this.safeStringConversion(value.value);
+        }
+        // Handle objects with toString method
+        if (typeof value.toString === 'function' && value.toString !== Object.prototype.toString) {
+            try {
+                const result = value.toString();
+                if (result && result !== '[object Object]') {
+                    return result;
+                }
+            } catch (error) {
+                console.warn('Error calling toString:', error);
+            }
+        }
+        // Handle structured objects with multiple fields
+        if (typeof value === 'object') {
+            const meaningfulFields = [];
+            // Common field names to extract
+            const fieldNames = ['title', 'description', 'category', 'item', 'type', 'status'];
+            fieldNames.forEach(fieldName => {
+                if (value[fieldName] && this.shouldDisplayValue(value[fieldName])) {
+                    meaningfulFields.push(this.safeStringConversion(value[fieldName]));
+                }
+            });
+            if (meaningfulFields.length > 0) {
+                return meaningfulFields.join(' - ');
+            }
+        }
+        // Last resort
+        return this.safeStringConversion(value);
+    }
+    // ============================================================================
+    // ENHANCED FIELD-SPECIFIC FORMATTING METHODS
+    // ============================================================================
+    formatYesNoValue(value, fieldConfig) {
+        // Handle custom options first
+        if (fieldConfig?.customOptions && Array.isArray(fieldConfig.customOptions)) {
+            const option = fieldConfig.customOptions.find(opt => opt.value === value);
+            if (option) {
+                return this.getLocalizedLabel(option.label);
+            }
+        }
+        // Standard yes/no
+        if (this.isYesValue(value, fieldConfig)) {
+            return this.getTranslatedText('common.yes');
+        }
+        if (this.isNoValue(value, fieldConfig)) {
+            return this.getTranslatedText('common.no');
+        }
+        return this.safeStringConversion(value);
+    }
+    formatYesNoWithOptionsValue(value, fieldConfig, context = {}) {
+        if (typeof value !== 'object' || value.main === undefined) {
+            return this.formatYesNoValue(value, fieldConfig);
+        }
+        // FIXED: Don't call extractStructuredValue to avoid recursion
+        // Just format the main value for summary mode or detailed contexts
+        return this.formatYesNoValue(value.main, fieldConfig);
+    }
+    formatSelectValue(value, fieldConfig) {
+        return this.getOptionDisplayName(fieldConfig?.options, value, fieldConfig);
+    }
+    formatMultiSelectValue(value, fieldConfig) {
+        if (!Array.isArray(value)) {
+            return this.formatSelectValue(value, fieldConfig);
+        }
+        return value.map(v => this.getOptionDisplayName(fieldConfig?.options, v, fieldConfig));
+    }
+    formatSelectWithOtherValue(value, fieldConfig) {
+        if (typeof value === 'object' && value.main) {
+            if (value.main === 'other' && value.other) {
+                return String(value.other)
+                    .trim();
+            }
+            return this.getOptionDisplayName(fieldConfig?.options, value.main, fieldConfig);
+        }
+        return this.getOptionDisplayName(fieldConfig?.options, value, fieldConfig);
+    }
+    formatMultiSelectWithOtherValue(value, fieldConfig) {
+        if (typeof value === 'object' && value.main) {
+            const mainValues = Array.isArray(value.main) ?
+                value.main.map(v => this.getOptionDisplayName(fieldConfig?.options, v, fieldConfig)) : [];
+            if (value.other && String(value.other)
+                .trim()) {
+                mainValues.push(String(value.other)
+                    .trim());
+            }
+            return mainValues;
+        }
+        return Array.isArray(value) ? value : [value];
+    }
+    formatContactValue(value) {
+        return value ? String(value)
+            .trim() : '';
+    }
+    formatNumericValue(value, fieldConfig) {
+        if (typeof value === 'number') {
+            const formatted = fieldConfig?.type === 'percentage' ? `${value}%` : value.toString();
+            return formatted;
+        }
+        return this.safeStringConversion(value);
+    }
+    formatTextareaValue(value, context = {}) {
+        if (typeof value === 'string') {
+            if (context.summaryMode && value.length > 100) {
+                return value.substring(0, 100) + '...';
+            }
+        }
+        return this.safeStringConversion(value);
+    }
+    formatSlidingWindowRangeValue(value, fieldConfig) {
+        if (typeof value === 'object' && value.min !== undefined && value.max !== undefined) {
+            const formatValue = fieldConfig?.formatValue || ((val) => `${parseInt(val).toLocaleString()}`);
+            return `${formatValue(value.min)} - ${formatValue(value.max)}`;
+        }
+        return this.safeStringConversion(value);
+    }
+    formatOptionsSliderValue(value, fieldConfig) {
+        if (typeof value === 'object' && value.display) {
+            return String(value.display);
+        }
+        if (fieldConfig?.options && Array.isArray(fieldConfig.options)) {
+            const option = fieldConfig.options.find(opt => opt.value === value);
+            if (option) {
+                return option.display || option.label || String(value);
+            }
+        }
+        return this.safeStringConversion(value);
+    }
+    formatDefaultValue(value) {
+        return this.safeStringConversion(value);
+    }
+    // ============================================================================
+    // ENHANCED: Safe string conversion method with HTML line breaks for calendars
+    // ============================================================================
+    /**
+     * UPDATED: Safe string conversion method with HTML line breaks for calendar arrays
+     */
+    safeStringConversion(value, fieldConfig = null) {
+        // Handle null/undefined
+        if (value === null || value === undefined) {
+            return '';
+        }
+        // Handle arrays with special formatting for calendar fields
+        if (Array.isArray(value)) {
+            // Check if this is a calendar field array
+            const isCalendarArray = value.some(item =>
+                typeof item === 'object' && (item.displayText || (item.date && item.timeOfDay))
+            );
+            if (isCalendarArray && value.length > 1) {
+                // FIX: Use HTML line breaks for calendar arrays with multiple items
+                return value.map(item => {
+                        const formatted = this.safeStringConversion(item);
+                        return formatted ? `• ${formatted}` : '';
+                    })
+                    .filter(item => item !== '')
+                    .join('<br>');
+            } else {
+                // Regular array formatting with commas
+                return value.map(item => this.safeStringConversion(item))
+                    .filter(item => item !== '')
+                    .join(', ');
+            }
+        }
+        // Handle objects
+        if (typeof value === 'object' && value !== null) {
+            // Check for calendar-specific properties first
+            if (value.displayText) {
+                return String(value.displayText);
+            }
+            if (value.date && value.timeOfDay) {
+                return `${value.date} - ${value.timeOfDay}`;
+            }
+            // Try toString first
+            if (typeof value.toString === 'function' && value.toString !== Object.prototype.toString) {
+                try {
+                    const result = value.toString();
+                    if (result && result !== '[object Object]') {
+                        return result;
+                    }
+                } catch (error) {
+                    console.warn('Error calling toString:', error);
+                }
+            }
+            // Check for other common display fields
+            if (value.display) {
+                return String(value.display);
+            }
+            if (value.label) {
+                return String(value.label);
+            }
+            if (value.name) {
+                return String(value.name);
+            }
+            if (value.value !== undefined) {
+                return String(value.value);
+            }
+            // Try JSON.stringify as last resort
+            try {
+                const jsonStr = JSON.stringify(value);
+                if (jsonStr && jsonStr !== '{}' && jsonStr !== 'null') {
+                    return jsonStr;
+                }
+            } catch (error) {
+                console.warn('Error stringifying object:', error);
+            }
+            return String(value);
+        }
+        // Handle primitives
+        return String(value);
+    }
+    // ============================================================================
+    // UTILITY METHODS
+    // ============================================================================
+    /**
+     * UPDATED: shouldDisplayValue with better object checking
+     */
+    shouldDisplayValue(value) {
+        if (value === undefined || value === null || value === '') {
+            return false;
+        }
+        if (Array.isArray(value) && value.length === 0) {
+            return false;
+        }
+        // Handle objects
+        if (typeof value === 'object' && value !== null) {
+            // Check if object has meaningful content
+            if (value._separateFields) {
+                // For CategoryItemFilterField-like objects
+                return !!(value.category || value.item);
+            }
+            // Check for common meaningful properties
+            const meaningfulProps = ['displayText', 'display', 'label', 'name', 'value', 'selectedCategory', 'selectedItem', 'date', 'timeOfDay'];
+            const hasMeaningfulContent = meaningfulProps.some(prop => {
+                const propValue = value[prop];
+                return propValue !== undefined && propValue !== null && propValue !== '';
+            });
+            if (hasMeaningfulContent) {
+                return true;
+            }
+            // Check if object has any non-empty values
+            try {
+                const stringified = JSON.stringify(value);
+                return stringified !== '{}' && stringified !== 'null' && stringified !== '[]';
+            } catch (error) {
+                return true; // If we can't stringify, assume it has content
+            }
+        }
+        return true;
+    }
+    isYesValue(value, fieldConfig) {
+        if (fieldConfig?.customOptions && Array.isArray(fieldConfig.customOptions)) {
+            return value === fieldConfig.customOptions[0]?.value;
+        }
+        return value === true || value === 'yes' || value === 'true';
+    }
+    isNoValue(value, fieldConfig) {
+        if (fieldConfig?.customOptions && Array.isArray(fieldConfig.customOptions)) {
+            return value === fieldConfig.customOptions[1]?.value;
+        }
+        return value === false || value === 'no' || value === 'false';
+    }
+    getOptionDisplayName(options, value, fieldConfig) {
+        if (!options || !value) return this.safeStringConversion(value);
+        // Handle data path resolution
+        if (typeof options === 'string' && this.creatFormInstance) {
+            try {
+                options = this.creatFormInstance.getData(options);
+            } catch (error) {
+                console.error('Error getting data for options path:', options, error);
+                return this.safeStringConversion(value);
+            }
+        }
+        // Handle subsection options (for select-subsections)
+        if (fieldConfig?.type === 'select-subsections' || fieldConfig?.type === 'multiselect-subsections') {
+            if (fieldConfig.subsectionOptions || fieldConfig.options) {
+                const subsections = fieldConfig.subsectionOptions || fieldConfig.options;
+                for (const section of subsections) {
+                    if (section.subcategories) {
+                        const option = section.subcategories.find(opt => opt.id === value);
+                        if (option) {
+                            return this.getLocalizedLabel(option.name || option.label);
+                        }
+                    }
+                }
+            }
+        }
+        // Handle regular options array
+        if (Array.isArray(options)) {
+            const option = options.find(opt => opt.id === value);
+            if (option) {
+                return this.getLocalizedLabel(option.name || option.label);
+            }
+        }
+        return this.safeStringConversion(value);
+    }
+    getLocalizedLabel(label) {
+        if (typeof label === 'object' && label !== null) {
+            return label[this.language] || label.en || label.fr || Object.values(label)[0];
+        }
+        return String(label || '');
+    }
+    getTranslatedText(path) {
+        try {
+            // Method 1: Try the creatFormInstance getText method
+            if (this.creatFormInstance && this.creatFormInstance.getText) {
+                const translated = this.creatFormInstance.getText(path);
+                if (translated && translated !== path && !translated.includes('.')) {
+                    return translated;
+                }
+            }
+            // Method 2: Try direct access to form data translations
+            if (this.creatFormInstance && this.creatFormInstance.formData && this.creatFormInstance.formData.translations) {
+                const translations = this.creatFormInstance.formData.translations[this.language];
+                if (translations) {
+                    const keys = path.split('.');
+                    let value = translations;
+                    for (const key of keys) {
+                        value = value?.[key];
+                    }
+                    if (value && typeof value === 'string') {
+                        return value;
+                    }
+                }
+            }
+            // Method 3: Try fallback translations
+            const fallback = this.fallbackTranslations[this.language]?.[path];
+            if (fallback) {
+                return fallback;
+            }
+            // Method 4: Try English fallback
+            const englishFallback = this.fallbackTranslations.en?.[path];
+            if (englishFallback) {
+                return englishFallback;
+            }
+            return path;
+        } catch (error) {
+            console.error('Error getting translated text:', error);
+            return this.fallbackTranslations[this.language]?.[path] ||
+                this.fallbackTranslations.en?.[path] ||
+                path;
+        }
+    }
+}
+
+export default FieldValueFormatter;
+

--- a/src/data/FormDataProcessor.js
+++ b/src/data/FormDataProcessor.js
@@ -1,0 +1,191 @@
+import FieldValueFormatter from "./FieldValueFormatter.js";
+class FormDataProcessor {
+    constructor(creatFormInstance) {
+        this.creatFormInstance = creatFormInstance;
+        this.formatter = new FieldValueFormatter(creatFormInstance);
+        this.config = creatFormInstance?.config || {};
+        this.language = this.config.language || 'fr';
+    }
+    /**
+     * Process form data using field configurations (same approach as CustomField)
+     */
+    processFormData(originalFormValues) {
+        const fieldConfigurations = this.getFieldConfigurations();
+        const processedData = {};
+        // Process each field value using its configuration
+        Object.keys(originalFormValues)
+            .forEach(fieldName => {
+                const fieldValue = originalFormValues[fieldName];
+                const fieldConfig = this.findFieldConfiguration(fieldName, fieldConfigurations);
+                if (fieldConfig && this.formatter.shouldDisplayValue(fieldValue)) {
+                    processedData[fieldName] = this.processFieldValue(fieldConfig, fieldValue, originalFormValues);
+                }
+            });
+        return processedData;
+    }
+    /**
+     * Process individual field value using the same technique as CustomField
+     */
+    processFieldValue(fieldConfig, fieldValue, allFormValues) {
+        // Get the structured value extraction (like CustomField does)
+        const structured = this.formatter.extractStructuredValue(fieldConfig, fieldValue);
+        return {
+            fieldId: fieldConfig.id || fieldConfig.name,
+            fieldType: fieldConfig.type,
+            label: this.getFieldLabel(fieldConfig),
+            displayValue: structured.displayValue,
+            rawValue: structured.rawValue,
+            // For complex fields, include structured information
+            ...(structured.hasSubFields && {
+                mainValue: structured.mainValue,
+                mainDisplayValue: structured.mainDisplayValue,
+                subFields: structured.subFields
+            }),
+            // For array fields, provide different formats
+            ...(Array.isArray(structured.displayValue) && {
+                array: structured.displayValue,
+                string: structured.displayValue.join(', '),
+                count: structured.displayValue.length
+            })
+        };
+    }
+    /**
+     * Get field configurations from the form (same as CustomField approach)
+     */
+    getFieldConfigurations() {
+        const configs = [];
+        if (this.creatFormInstance.formConfig?.steps) {
+            this.creatFormInstance.formConfig.steps.forEach(stepConfig => {
+                if (stepConfig.fields) {
+                    configs.push(...this.extractFieldConfigs(stepConfig.fields));
+                }
+            });
+        }
+        return configs;
+    }
+    /**
+     * Extract field configurations including nested fields (yesFields, noFields, etc.)
+     */
+    extractFieldConfigs(fields) {
+        const configs = [];
+        fields.forEach(fieldConfig => {
+            configs.push(fieldConfig);
+            // Extract nested field configurations
+            if (fieldConfig.yesFields) {
+                configs.push(...this.extractFieldConfigs(fieldConfig.yesFields));
+            }
+            if (fieldConfig.yesField) {
+                configs.push(fieldConfig.yesField);
+            }
+            if (fieldConfig.noFields) {
+                configs.push(...this.extractFieldConfigs(fieldConfig.noFields));
+            }
+            if (fieldConfig.noField) {
+                configs.push(fieldConfig.noField);
+            }
+        });
+        return configs;
+    }
+    /**
+     * Find field configuration by name (same as CustomField approach)
+     */
+    findFieldConfiguration(fieldName, fieldConfigurations) {
+        return fieldConfigurations.find(config =>
+            (config.name === fieldName) ||
+            (config.id === fieldName)
+        ) || null;
+    }
+    /**
+     * Get field label using the same approach as CustomField
+     */
+    getFieldLabel(fieldConfig) {
+        const fieldId = fieldConfig.id || fieldConfig.name;
+        // Try to get translated label
+        if (this.creatFormInstance.getText) {
+            const translatedLabel = this.creatFormInstance.getText(`fields.${fieldId}`);
+            if (translatedLabel && translatedLabel !== `fields.${fieldId}`) {
+                return translatedLabel;
+            }
+        }
+        // Fallback to config label
+        return fieldConfig.label || fieldId;
+    }
+    /**
+     * Create sections based on form structure (not hardcoded field names)
+     */
+    createSections(processedData) {
+        const sections = {};
+        if (this.creatFormInstance.formConfig?.steps) {
+            this.creatFormInstance.formConfig.steps.forEach((stepConfig, stepIndex) => {
+                const sectionData = this.createSectionFromStep(stepConfig, stepIndex, processedData);
+                if (Object.keys(sectionData)
+                    .length > 0) {
+                    const sectionId = this.getSectionId(stepConfig, stepIndex);
+                    sections[sectionId] = {
+                        sectionType: sectionId,
+                        title: this.getSectionTitle(stepConfig, stepIndex),
+                        index: stepIndex,
+                        ...sectionData
+                    };
+                }
+            });
+        }
+        return sections;
+    }
+    /**
+     * Create section data from step configuration
+     */
+    createSectionFromStep(stepConfig, stepIndex, processedData) {
+        const sectionData = {};
+        if (stepConfig.fields) {
+            stepConfig.fields.forEach(fieldConfig => {
+                const fieldName = fieldConfig.id || fieldConfig.name;
+                const fieldData = processedData[fieldName];
+                if (fieldData) {
+                    sectionData[fieldName] = fieldData;
+                }
+            });
+        }
+        return sectionData;
+    }
+    /**
+     * Get section ID from step configuration
+     */
+    getSectionId(stepConfig, stepIndex) {
+        if (stepConfig.sectionId) {
+            return stepConfig.sectionId;
+        }
+        // Generate semantic section IDs based on content
+        const fieldTypes = stepConfig.fields?.map(f => f.type) || [];
+        if (fieldTypes.includes('email') || fieldTypes.includes('phone')) {
+            return 'contact_information';
+        }
+        if (fieldTypes.includes('textarea') && stepConfig.fields?.some(f => f.id?.includes('description'))) {
+            return 'project_details';
+        }
+        if (fieldTypes.includes('serviceCard') || fieldTypes.includes('calendar')) {
+            return 'service_selection';
+        }
+        if (fieldTypes.includes('yesno-with-options')) {
+            return 'feature_configuration';
+        }
+        return `step_${stepIndex}`;
+    }
+    /**
+     * Get section title from step configuration
+     */
+    getSectionTitle(stepConfig, stepIndex) {
+        // Try to get translated title
+        if (this.creatFormInstance.getText) {
+            const translatedTitle = this.creatFormInstance.getText(`steps.${stepIndex}.title`);
+            if (translatedTitle && translatedTitle !== `steps.${stepIndex}.title`) {
+                return translatedTitle;
+            }
+        }
+        // Fallback to config title or generated title
+        return stepConfig.title || `Step ${stepIndex + 1}`;
+    }
+}
+
+export default FormDataProcessor;
+

--- a/src/fields/BaseField.js
+++ b/src/fields/BaseField.js
@@ -1,0 +1,284 @@
+class BaseField {
+    constructor(factory, config) {
+        this.factory = factory;
+        this.id = config.id;
+        this.name = config.name || config.id;
+        this.label = config.label || '';
+        this.required = config.required || false;
+        this.placeholder = config.placeholder || '';
+        this.value = config.value || config.defaultValue || '';
+        this.containerClass = config.containerClass || 'form-group';
+        this.onChange = config.onChange || null;
+        this.customValidation = config.customValidation || null;
+        // Custom error messages support
+        this.customErrorMessage = config.customErrorMessage || null;
+        this.customErrorMessages = config.customErrorMessages || {};
+        this.infoButton = config.infoButton || null;
+        this.element = null;
+        this.errorElement = null;
+        this.container = null;
+        this.infoPanel = null;
+        this.infoPanelInstance = null;
+    }
+    // Get field-specific error message
+    getFieldErrorMessage(errorType = 'required') {
+        // Priority: 1. Custom message for specific error type, 2. General custom message, 3. Factory default
+        if (this.customErrorMessages[errorType]) {
+            return this.customErrorMessages[errorType];
+        }
+        if (errorType === 'required' && this.customErrorMessage) {
+            return this.customErrorMessage;
+        }
+        // Fallback to factory defaults based on error type
+        switch (errorType) {
+        case 'required':
+            return this.factory.getText('fieldRequired');
+        case 'invalid':
+        case 'email':
+            return this.factory.getText('emailInvalid');
+        case 'phone':
+            return this.factory.getText('phoneInvalid');
+        case 'url':
+            return this.factory.getText('urlInvalid');
+        case 'selectAtLeastOne':
+            return this.factory.getText('selectAtLeastOne');
+        case 'serviceRequired':
+            return this.factory.getText('serviceRequired');
+        case 'dateTimeRequired':
+            return this.factory.getText('dateTimeRequired');
+        default:
+            return this.factory.getText('fieldRequired');
+        }
+    }
+    createContainer() {
+        this.container = document.createElement('div');
+        this.container.className = this.containerClass;
+        return this.container;
+    }
+    createLabel() {
+        const labelContainer = document.createElement('div');
+        labelContainer.className = 'label-container';
+        const label = document.createElement('label');
+        label.className = 'form-label';
+        label.setAttribute('for', this.id);
+        label.textContent = this.label;
+        if (this.required) {
+            label.classList.add('required');
+            const requiredSpan = document.createElement('span');
+            //requiredSpan.textContent = ' *';
+            requiredSpan.className = 'required-indicator';
+            label.appendChild(requiredSpan);
+        }
+        if (this.infoButton) {
+            const infoBtn = document.createElement('button');
+            infoBtn.className = 'info-button';
+            infoBtn.type = 'button';
+            infoBtn.setAttribute('aria-label', 'Plus d\'informations');
+            infoBtn.innerHTML = this.factory.SVG_ICONS.INFO;
+            infoBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                this.toggleInfoPanel();
+            });
+            label.appendChild(infoBtn);
+            const infoPanel = this.createInfoPanel();
+            if (infoPanel) {
+                labelContainer.appendChild(label);
+                labelContainer.appendChild(infoPanel);
+                return labelContainer;
+            }
+        }
+        labelContainer.appendChild(label);
+        return labelContainer;
+    }
+    createQuestionLabel() {
+        const labelContainer = document.createElement('div');
+        labelContainer.className = 'label-container';
+        const label = document.createElement('label');
+        label.className = 'question-label';
+        label.textContent = this.label;
+        if (this.required) {
+            label.classList.add('required');
+        }
+        if (this.infoButton) {
+            const infoBtn = document.createElement('button');
+            infoBtn.className = 'info-button';
+            infoBtn.type = 'button';
+            infoBtn.setAttribute('aria-label', 'Plus d\'informations');
+            infoBtn.innerHTML = this.factory.SVG_ICONS.INFO;
+            infoBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                this.toggleInfoPanel();
+            });
+            label.appendChild(infoBtn);
+            const infoPanel = this.createInfoPanel();
+            if (infoPanel) {
+                labelContainer.appendChild(label);
+                labelContainer.appendChild(infoPanel);
+                return labelContainer;
+            }
+        }
+        labelContainer.appendChild(label);
+        return labelContainer;
+    }
+    createInfoPanel() {
+        if (!this.infoButton) return null;
+        this.infoPanel = document.createElement('div');
+        this.infoPanel.className = 'info-panel';
+        this.infoPanel.id = `${this.id}-info`;
+        if (this.infoButton.title) {
+            const titleEl = document.createElement('div');
+            titleEl.className = 'info-title';
+            titleEl.textContent = this.infoButton.title;
+            this.infoPanel.appendChild(titleEl);
+        }
+        const contentEl = document.createElement('div');
+        contentEl.innerHTML = this.infoButton.content;
+        this.infoPanel.appendChild(contentEl);
+        const closeButton = document.createElement('button');
+        closeButton.className = 'close-info';
+        closeButton.type = 'button';
+        closeButton.setAttribute('aria-label', 'Fermer');
+        closeButton.innerHTML = this.factory.SVG_ICONS.CLOSE;
+        closeButton.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.hideInfoPanel();
+        });
+        this.infoPanel.appendChild(closeButton);
+        return this.infoPanel;
+    }
+    toggleInfoPanel() {
+        if (!this.infoPanel) return;
+        const isCurrentlyShown = this.infoPanel.classList.contains('show');
+        if (isCurrentlyShown) {
+            this.hideInfoPanel();
+        } else {
+            this.showInfoPanel();
+        }
+    }
+    showInfoPanel() {
+        if (!this.infoPanel) return;
+        this.factory.closeAllInfoPanels();
+        this.infoPanel.classList.add('show');
+        this.infoPanelInstance = {
+            element: this.infoPanel,
+            button: this.container.querySelector('.info-button'),
+            close: () => this.hideInfoPanel()
+        };
+        this.factory.registerInfoPanel(this.infoPanelInstance);
+    }
+    hideInfoPanel() {
+        if (this.infoPanel) {
+            this.infoPanel.classList.remove('show');
+            if (this.infoPanelInstance) {
+                this.factory.unregisterInfoPanel(this.infoPanelInstance);
+                this.infoPanelInstance = null;
+            }
+        }
+    }
+    createErrorElement() {
+        this.errorElement = document.createElement('div');
+        this.errorElement.className = 'error-message';
+        this.errorElement.id = `error-${this.id}`;
+        this.errorElement.innerHTML = `
+            <div class="error-icon">!</div>
+            <span class="error-text">${this.getFieldErrorMessage('required')}</span>
+        `;
+        return this.errorElement;
+    }
+    showError(message) {
+        if (this.errorElement) {
+            const errorText = this.errorElement.querySelector('.error-text');
+            if (errorText) {
+                errorText.textContent = message || this.getFieldErrorMessage('required');
+            }
+            this.errorElement.classList.add('show');
+        }
+    }
+    hideError() {
+        if (this.errorElement) {
+            this.errorElement.classList.remove('show');
+        }
+    }
+    validate() {
+        if (this.required && !this.getValue()) {
+            this.showError(this.getFieldErrorMessage('required'));
+            return false;
+        }
+        if (this.customValidation) {
+            const result = this.customValidation(this.getValue());
+            if (result !== true) {
+                this.showError(result);
+                return false;
+            }
+        }
+        this.hideError();
+        return true;
+    }
+    getValue() {
+        return this.value;
+    }
+    setValue(value) {
+        this.value = value;
+        if (this.element) {
+            this.element.value = value;
+        }
+    }
+    handleChange() {
+        if (this.onChange) {
+            this.onChange(this.getValue());
+        }
+        if (this.factory.onChangeCallback) {
+            this.factory.onChangeCallback(this.name, this.getValue());
+        }
+        this.factory.formValues[this.name] = this.getValue();
+    }
+    show() {
+        if (this.container) {
+            this.container.style.display = 'block';
+        }
+    }
+    hide() {
+        if (this.container) {
+            this.container.style.display = 'none';
+        }
+    }
+    enable() {
+        if (this.container) {
+            const inputs = this.container.querySelectorAll('input, select, button');
+            inputs.forEach(input => input.disabled = false);
+        }
+    }
+    disable() {
+        if (this.container) {
+            const inputs = this.container.querySelectorAll('input, select, button');
+            inputs.forEach(input => input.disabled = true);
+        }
+    }
+    cleanup() {
+        this.hideInfoPanel();
+    }
+    render() {
+        throw new Error('render() method must be implemented by subclass');
+    }
+    resetToInitial() {
+        this.value = this.defaultValue || '';
+        this.hideError();
+        if (this.element) {
+            if (this.element.type === 'checkbox' || this.element.type === 'radio') {
+                this.element.checked = false;
+            } else {
+                this.element.value = '';
+            }
+        }
+    }
+    clearVisualState() {
+        this.hideError();
+        this.hideInfoPanel();
+    }
+}
+
+export default BaseField;
+

--- a/src/fields/InputFields.js
+++ b/src/fields/InputFields.js
@@ -1,0 +1,279 @@
+import BaseField from "./BaseField.js";
+class TextField extends BaseField {
+    constructor(factory, config) {
+        super(factory, config);
+        this.maxLength = config.maxLength || null;
+        this.minLength = config.minLength || null;
+    }
+    validate() {
+        const value = this.getValue();
+        if (this.required && !value) {
+            this.showError(this.getFieldErrorMessage('required'));
+            return false;
+        }
+        if (this.minLength && value.length < this.minLength) {
+            const message = this.getFieldErrorMessage('minLength') ||
+                `Minimum ${this.minLength} characters required`;
+            this.showError(message);
+            return false;
+        }
+        return super.validate();
+    }
+    render() {
+        const container = this.createContainer();
+        const labelContainer = this.createLabel();
+        this.element = document.createElement('input');
+        this.element.type = 'text';
+        this.element.id = this.id;
+        this.element.name = this.name;
+        this.element.placeholder = this.placeholder;
+        this.element.value = this.value;
+        if (this.maxLength) {
+            this.element.maxLength = this.maxLength;
+        }
+        const errorElement = this.createErrorElement();
+        container.appendChild(labelContainer);
+        container.appendChild(this.element);
+        container.appendChild(errorElement);
+        this.element.addEventListener('input', () => {
+            this.value = this.element.value.trim();
+            if (this.value) this.hideError();
+            this.handleChange();
+        });
+        this.container = container;
+        return container;
+    }
+}
+/**
+ * TextAreaField - Multiple text field with personalized error messages
+ */
+class TextAreaField extends BaseField {
+    constructor(factory, config) {
+        super(factory, config);
+        this.rows = config.rows || 4;
+        this.maxLength = config.maxLength || 500;
+        this.showCounter = config.showCounter !== false;
+        this.minHeight = config.minHeight || 120;
+    }
+    validate() {
+        const value = this.getValue();
+        if (this.required && !value) {
+            this.showError(this.getFieldErrorMessage('required'));
+            return false;
+        }
+        return super.validate();
+    }
+    render() {
+        const container = this.createContainer();
+        const label = this.createLabel();
+        const textareaWrapper = document.createElement('div');
+        textareaWrapper.className = 'textarea-wrapper';
+        this.element = document.createElement('div');
+        this.element.id = this.id;
+        this.element.className = 'custom-textarea';
+        this.element.setAttribute('contenteditable', 'true');
+        this.element.setAttribute('data-placeholder', this.placeholder);
+        this.element.style.minHeight = `${this.minHeight}px`;
+        const lineHeight = 20;
+        this.element.style.height = `${Math.max(this.minHeight, this.rows * lineHeight + 24)}px`;
+        if (this.value) {
+            this.element.textContent = this.value;
+        }
+        textareaWrapper.appendChild(this.element);
+        if (this.showCounter) {
+            this.counterElement = document.createElement('div');
+            this.counterElement.className = 'char-counter';
+            this.counterElement.innerHTML = `<span id="${this.id}-counter">${this.value.length}</span>/${this.maxLength}`;
+            textareaWrapper.appendChild(this.counterElement);
+        }
+        const errorElement = this.createErrorElement();
+        container.appendChild(label);
+        container.appendChild(textareaWrapper);
+        container.appendChild(errorElement);
+        this.element.addEventListener('input', () => {
+            let text = this.element.textContent || '';
+            if (this.maxLength && text.length > this.maxLength) {
+                text = text.substring(0, this.maxLength);
+                this.element.textContent = text;
+                const range = document.createRange();
+                const sel = window.getSelection();
+                range.selectNodeContents(this.element);
+                range.collapse(false);
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
+            this.value = text.trim();
+            if (this.value) this.hideError();
+            if (this.showCounter) {
+                const counter = container.querySelector(`#${this.id}-counter`);
+                if (counter) counter.textContent = text.length;
+            }
+            this.handleChange();
+        });
+        this.element.addEventListener('focus', () => {
+            if (this.element.textContent === '') {
+                this.element.classList.add('focused');
+            }
+        });
+        this.element.addEventListener('blur', () => {
+            this.element.classList.remove('focused');
+        });
+        this.element.addEventListener('paste', (e) => {
+            e.preventDefault();
+            const text = (e.clipboardData || window.clipboardData)
+                .getData('text/plain');
+            const maxLength = this.maxLength || text.length;
+            const finalText = text.substring(0, maxLength);
+            document.execCommand('insertText', false, finalText);
+        });
+        this.container = container;
+        return container;
+    }
+    getValue() {
+        return this.element ? (this.element.textContent || '')
+            .trim() : this.value;
+    }
+    setValue(value) {
+        this.value = value;
+        if (this.element) {
+            this.element.textContent = value;
+            if (this.showCounter && this.counterElement) {
+                const counter = this.counterElement.querySelector(`#${this.id}-counter`);
+                if (counter) counter.textContent = value.length;
+            }
+        }
+    }
+}
+/**
+ * EmailField - Email field with personalized error messages
+ */
+class EmailField extends TextField {
+    validate() {
+        const value = this.getValue();
+        if (this.required && !value) {
+            this.showError(this.getFieldErrorMessage('required'));
+            return false;
+        }
+        if (value && !FormFieldFactory.ValidationUtils.isValidEmail(value)) {
+            this.showError(this.getFieldErrorMessage('invalid'));
+            return false;
+        }
+        return super.validate();
+    }
+    render() {
+        const container = super.render();
+        this.element.type = 'email';
+        // REPLACE with this:
+        this.element.addEventListener('input', () => {
+            this.value = this.element.value.trim();
+            if (this.value) {
+                this.hideError(); // Only hide error, don't show it
+            }
+            this.handleChange();
+        });
+        // ADD this new blur event listener:
+        this.element.addEventListener('blur', () => {
+            const value = this.element.value.trim();
+            if (value) {
+                if (FormFieldFactory.ValidationUtils.isValidEmail(value)) {
+                    this.hideError();
+                } else {
+                    this.showError(this.getFieldErrorMessage('invalid'));
+                }
+            }
+            this.handleChange();
+        });
+        return container;
+    }
+}
+/**
+ * PhoneField - Phone field with personalized error messages
+ */
+class PhoneField extends TextField {
+    validate() {
+        const value = this.getValue();
+        if (this.required && !value) {
+            this.showError(this.getFieldErrorMessage('required'));
+            return false;
+        }
+        if (value && !FormFieldFactory.ValidationUtils.isValidPhoneNumber(value)) {
+            this.showError(this.getFieldErrorMessage('phone'));
+            return false;
+        }
+        return super.validate();
+    }
+    render() {
+        const container = super.render();
+        this.element.type = 'tel';
+        // REPLACE with this:
+        this.element.addEventListener('input', () => {
+            this.value = this.element.value.trim();
+            if (this.value) {
+                this.hideError(); // Only hide error, don't show it
+            }
+            this.handleChange();
+        });
+        // ADD this new blur event listener:
+        this.element.addEventListener('blur', () => {
+            const value = this.element.value.trim();
+            if (value) {
+                if (FormFieldFactory.ValidationUtils.isValidPhoneNumber(value)) {
+                    this.hideError();
+                } else {
+                    this.showError(this.getFieldErrorMessage('phone'));
+                }
+            }
+            this.handleChange();
+        });
+        return container;
+    }
+    getValue() {
+        const value = this.element ? this.element.value.trim() : this.value;
+        return FormFieldFactory.ValidationUtils.formatPhoneNumber(value);
+    }
+}
+/**
+ * UrlField - URL field with personalized error messages
+ */
+class UrlField extends TextField {
+    validate() {
+        const value = this.getValue();
+        if (this.required && !value) {
+            this.showError(this.getFieldErrorMessage('required'));
+            return false;
+        }
+        if (value && !FormFieldFactory.ValidationUtils.isValidUrl(value)) {
+            this.showError(this.getFieldErrorMessage('url'));
+            return false;
+        }
+        return super.validate();
+    }
+    render() {
+        const container = super.render();
+        this.element.type = 'url';
+        this.element.addEventListener('blur', () => {
+            const value = this.element.value.trim();
+            if (value) {
+                if (FormFieldFactory.ValidationUtils.isValidUrl(value)) {
+                    const normalized = FormFieldFactory.ValidationUtils.normalizeUrl(value);
+                    this.element.value = normalized;
+                    this.value = normalized;
+                    this.hideError();
+                } else {
+                    this.showError(this.getFieldErrorMessage('url'));
+                }
+            }
+            this.handleChange();
+        });
+        this.element.addEventListener('input', () => {
+            this.value = this.element.value.trim();
+            if (this.value && FormFieldFactory.ValidationUtils.isValidUrl(this.value)) {
+                this.hideError();
+            }
+            this.handleChange();
+        });
+        return container;
+    }
+}
+
+export { TextField, TextAreaField, EmailField, PhoneField, UrlField };

--- a/src/form/FormFieldFactory.js
+++ b/src/form/FormFieldFactory.js
@@ -1,0 +1,21 @@
+import { MultiStepForm } from './MultiStepForm.js';
+import { TextField, TextAreaField, EmailField, PhoneField, UrlField } from '../fields/InputFields.js';
+
+class FormFieldFactory {
+  constructor(options = {}) {
+    this.container = options.container || document.body;
+    this.formValues = options.formValues || {};
+    this.onChangeCallback = options.onChange || null;
+    this.texts = options.texts || {};
+  }
+  getText(key) {
+    return this.texts[key] || key;
+  }
+  createTextField(config) { return new TextField(this, config); }
+  createTextAreaField(config) { return new TextAreaField(this, config); }
+  createEmailField(config) { return new EmailField(this, config); }
+  createPhoneField(config) { return new PhoneField(this, config); }
+  createUrlField(config) { return new UrlField(this, config); }
+  createMultiStepForm(config) { return new MultiStepForm(this, config); }
+}
+export default FormFieldFactory;

--- a/src/form/MultiStepForm.js
+++ b/src/form/MultiStepForm.js
@@ -1,0 +1,610 @@
+class MultiStepForm {
+    constructor(factory, config) {
+        this.factory = factory;
+        this.config = config;
+        this.steps = config.steps || [];
+        this.currentStep = 0;
+        this.formData = config.initialData || {};
+        this.onSubmit = config.onSubmit || null;
+        this.onStepChange = config.onStepChange || null;
+        this.validateOnNext = config.validateOnNext !== false;
+        this.showProgress = config.showProgress !== false;
+        this.saveProgressEnabled = config.saveProgress !== false;
+        this.storageKey = config.storageKey || 'multistep_form_data';
+        this.container = null;
+        this.stepInstances = [];
+        this.progressBar = null;
+        this.navigationButtons = null;
+        this.init();
+    }
+    init() {
+        this.factory.currentMultiStepForm = this;
+        this.createContainer();
+        this.createProgressBar();
+        this.createSteps();
+        this.createNavigation();
+        this.loadSavedProgress();
+        this.showCurrentStep();
+    }
+    createContainer() {
+        this.container = document.createElement('div');
+        this.container.className = 'multistep-form';
+        this.factory.container.appendChild(this.container);
+    }
+    createProgressBar() {
+        if (!this.showProgress) return;
+        this.progressBar = new ProgressBar(this, {
+            totalSteps: this.steps.length,
+            currentStep: this.currentStep
+        });
+        this.container.appendChild(this.progressBar.render());
+    }
+    createSteps() {
+        this.steps.forEach((stepConfig, index) => {
+            const step = new FormStep(this, {
+                ...stepConfig,
+                index: index,
+                isActive: index === this.currentStep
+            });
+            this.stepInstances.push(step);
+            this.container.appendChild(step.render());
+        });
+    }
+    createNavigation() {
+        this.navigationButtons = new NavigationButtons(this);
+        this.container.appendChild(this.navigationButtons.render());
+    }
+    showCurrentStep() {
+        this.stepInstances.forEach((step, index) => {
+            step.setActive(index === this.currentStep);
+        });
+        if (this.progressBar) {
+            this.progressBar.updateProgress(this.currentStep);
+        }
+        this.navigationButtons.updateButtons(this.currentStep, this.steps.length);
+        if (this.onStepChange) {
+            this.onStepChange(this.currentStep, this.stepInstances[this.currentStep]);
+        }
+    }
+    nextStep() {
+        if (this.validateOnNext && !this.validateCurrentStep()) {
+            return false;
+        }
+        if (this.currentStep < this.steps.length - 1) {
+            this.currentStep++;
+            this.showCurrentStep();
+            this.saveProgress();
+            return true;
+        }
+        return false;
+    }
+    previousStep() {
+        if (this.currentStep > 0) {
+            this.currentStep--;
+            this.showCurrentStep();
+            this.saveProgress();
+            return true;
+        }
+        return false;
+    }
+    goToStep(stepIndex) {
+        if (stepIndex >= 0 && stepIndex < this.steps.length) {
+            this.currentStep = stepIndex;
+            this.showCurrentStep();
+            this.saveProgress();
+            return true;
+        }
+        return false;
+    }
+    validateCurrentStep() {
+        return this.stepInstances[this.currentStep].validate();
+    }
+    validateAllSteps() {
+        return this.stepInstances.every(step => step.validate());
+    }
+    getFormData() {
+        const data = {};
+        this.stepInstances.forEach(step => {
+            Object.assign(data, step.getStepData());
+        });
+        return data;
+    }
+    setFormData(data) {
+        this.formData = {
+            ...this.formData,
+            ...data
+        };
+        this.stepInstances.forEach(step => {
+            step.setStepData(this.formData);
+        });
+    }
+    saveProgress() {
+        if (!this.saveProgressEnabled) return;
+        const progressData = {
+            currentStep: this.currentStep,
+            formData: this.getFormData(),
+            timestamp: Date.now()
+        };
+        localStorage.setItem(this.storageKey, JSON.stringify(progressData));
+    }
+    loadSavedProgress() {
+        if (!this.saveProgressEnabled) return;
+        try {
+            const saved = localStorage.getItem(this.storageKey);
+            if (saved) {
+                const progressData = JSON.parse(saved);
+                this.currentStep = progressData.currentStep || 0;
+                this.setFormData(progressData.formData || {});
+            }
+        } catch (e) {
+            console.warn('Failed to load saved progress:', e);
+        }
+    }
+    clearSavedProgress() {
+        localStorage.removeItem(this.storageKey);
+    }
+    reset() {
+        // Reset step and form data
+        this.currentStep = 0;
+        this.formData = {};
+        // Reset all field instances
+        this.stepInstances.forEach(step => {
+            step.reset();
+            // Also clear any error states
+            step.fieldInstances.forEach(field => {
+                field.hideError();
+                field.setValue('');
+            });
+        });
+        // Clear factory form values
+        this.factory.formValues = {};
+        // Close any open dropdowns and info panels
+        this.factory.closeAllDropdowns();
+        this.factory.closeAllInfoPanels();
+        // Clear saved progress
+        this.clearSavedProgress();
+        // Reset UI state
+        this.showCurrentStep();
+        // Reset any custom field content (like summaries)
+        this.stepInstances.forEach(step => {
+            step.fieldInstances.forEach(field => {
+                if (field.autoSummary && field.updateContent) {
+                    setTimeout(() => field.updateContent(), 100);
+                }
+            });
+        });
+    }
+    submit() {
+        if (!this.validateAllSteps()) {
+            return false;
+        }
+        const formData = this.getFormData();
+        if (this.onSubmit) {
+            const result = this.onSubmit(formData);
+            if (result !== false) {
+                this.clearSavedProgress();
+            }
+            return result;
+        }
+        this.clearSavedProgress();
+        return formData;
+    }
+}
+/**
+ * FormStep - Enhanced with subsection field support and row layout
+ */
+class FormStep {
+    constructor(multiStepForm, config) {
+        this.multiStepForm = multiStepForm;
+        this.factory = multiStepForm.factory;
+        this.config = config;
+        this.index = config.index;
+        this.title = config.title || `Step ${this.index + 1}`;
+        this.description = config.description || '';
+        this.fields = config.fields || [];
+        this.validationRules = config.validation || {};
+        this.conditionalLogic = config.conditionalLogic || {};
+        this.container = null;
+        this.fieldInstances = [];
+        this.isActive = config.isActive || false;
+    }
+    render() {
+        this.container = document.createElement('div');
+        this.container.className = `form-step ${this.isActive ? 'active' : 'hidden'}`;
+        this.container.setAttribute('data-step', this.index);
+        if (this.title) {
+            const titleElement = document.createElement('span');
+            titleElement.className = 'step-title';
+            titleElement.textContent = this.title;
+            this.container.appendChild(titleElement);
+        }
+        const fieldsContainer = document.createElement('div');
+        fieldsContainer.className = 'step-fields';
+        // Group fields by row
+        const fieldGroups = this.groupFields(this.fields);
+        fieldGroups.forEach(group => {
+            if (group.isRow) {
+                // Create row container
+                const rowContainer = document.createElement('div');
+                rowContainer.className = 'field-row';
+                group.fields.forEach(fieldConfig => {
+                    const colContainer = document.createElement('div');
+                    colContainer.className = 'field-col';
+                    const field = this.createField(fieldConfig);
+                    if (field) {
+                        this.fieldInstances.push(field);
+                        colContainer.appendChild(field.render());
+                    }
+                    rowContainer.appendChild(colContainer);
+                });
+                fieldsContainer.appendChild(rowContainer);
+            } else {
+                // Single field
+                const field = this.createField(group.fields[0]);
+                if (field) {
+                    this.fieldInstances.push(field);
+                    fieldsContainer.appendChild(field.render());
+                }
+            }
+        });
+        this.container.appendChild(fieldsContainer);
+        this.setupConditionalLogic();
+        return this.container;
+    }
+    groupFields(fields) {
+        const groups = [];
+        let i = 0;
+        while (i < fields.length) {
+            const currentField = fields[i];
+            if (currentField.row) {
+                // Find all fields with the same row identifier
+                const rowFields = [];
+                let j = i;
+                while (j < fields.length && fields[j].row === currentField.row) {
+                    rowFields.push(fields[j]);
+                    j++;
+                }
+                groups.push({
+                    isRow: true,
+                    fields: rowFields
+                });
+                i = j; // Skip the grouped fields
+                continue;
+            }
+            // Single field without row
+            groups.push({
+                isRow: false,
+                fields: [currentField]
+            });
+            i++;
+        }
+        return groups;
+    }
+    createField(config) {
+        const fieldType = config.type;
+        const fieldConfig = {
+            ...config,
+            onChange: (value) => {
+                this.handleFieldChange(config.name, value);
+                if (config.onChange) {
+                    config.onChange(value);
+                }
+            }
+        };
+        switch (fieldType) {
+        case 'text':
+            return this.factory.createTextField(fieldConfig);
+        case 'email':
+            return this.factory.createEmailField(fieldConfig);
+        case 'phone':
+            return this.factory.createPhoneField(fieldConfig);
+        case 'url':
+            return this.factory.createUrlField(fieldConfig);
+        case 'textarea':
+            return this.factory.createTextAreaField(fieldConfig);
+        case 'number':
+            return this.factory.createNumberField(fieldConfig);
+        case 'percentage':
+            return this.factory.createPercentageField(fieldConfig);
+        case 'options-stepper':
+            return this.factory.createOptionsStepperField(fieldConfig);
+        case 'yesno':
+            return this.factory.createYesNoField(fieldConfig);
+        case 'select':
+            return this.factory.createSingleSelectField(fieldConfig);
+        case 'multiselect':
+            return this.factory.createMultiSelectField(fieldConfig);
+        case 'select-subsections':
+            return this.factory.createSingleSelectSubsectionsField(fieldConfig);
+        case 'multiselect-subsections':
+            return this.factory.createMultiSelectSubsectionsField(fieldConfig);
+        case 'yesno-with-options':
+            return this.factory.createYesNoWithOptionsField(fieldConfig);
+        case 'select-with-other':
+            return this.factory.createSingleSelectWithOtherField(fieldConfig);
+        case 'multiselect-with-other':
+            return this.factory.createMultiSelectWithOtherField(fieldConfig);
+        case 'sliding-window-range':
+            return this.factory.createSlidingWindowRangeField(fieldConfig);
+        case 'dual-range':
+            return this.factory.createDualRangeField(fieldConfig);
+        case 'sliding window':
+            return this.factory.createSliderField(fieldConfig);
+        case 'slider':
+            return this.factory.createSlidingWindowSliderField(fieldConfig);
+        case 'options-slider':
+            return this.factory.createOptionsSliderField(fieldConfig);
+        case 'serviceCard':
+            return this.factory.createServiceCardField(fieldConfig);
+        case 'carousel':
+            return this.factory.createCarouselField(fieldConfig);
+        case 'filteredCarousel':
+            return this.factory.createFilteredCarouselField(fieldConfig);
+        case 'service-provider-calendar':
+            return this.factory.createServiceProviderCalendarField(fieldConfig);
+        case 'calendar':
+            return this.factory.createCalendarField(fieldConfig);
+        case 'item-calendar':
+            return this.factory.createItemCalendarField(fieldConfig);
+        case 'image-gallery':
+            return this.factory.createImageGalleryField(fieldConfig);
+        case 'manager':
+            return this.factory.createTabManager(fieldConfig);
+        case 'category-item-filter':
+            return this.factory.createCategoryItemFilterField(fieldConfig);
+        case 'category-item-calendar':
+            return this.factory.createCategoryAndItemCalendarField(fieldConfig);
+        case 'bookingCancellationCard':
+            return this.factory.createBookingCancellationCardField(fieldConfig);
+            // ===== NEW CUSTOM FIELD TYPES =====
+        case 'service-request-calendar':
+        case 'serviceRequestCalendar':
+            return this.factory.createServiceRequestCalendarField(fieldConfig);
+        case 'terms-checkbox':
+        case 'termsCheckbox':
+            return this.factory.createTermsCheckboxField(fieldConfig);
+        case 'category-request-file-upload':
+        case 'categoryRequestFileUpload':
+            return this.factory.createCategoryRequestFileUploadField(fieldConfig);
+        case 'currentAppointmentCard':
+            return this.factory.createCurrentAppointmentCardField(fieldConfig);
+        case 'custom':
+            // Handle custom fields with render functions
+            if (fieldConfig.render && typeof fieldConfig.render === 'function') {
+                return fieldConfig.render(this.factory, fieldConfig);
+            }
+            return new CustomField(this.factory, fieldConfig);
+        default:
+            console.warn(`Unknown field type: ${fieldType}`);
+            return null;
+        }
+    }
+    handleFieldChange(fieldName, value) {
+        this.multiStepForm.formData[fieldName] = value;
+        this.executeConditionalLogic(fieldName, value);
+        this.multiStepForm.saveProgress();
+    }
+    setupConditionalLogic() {
+        Object.keys(this.conditionalLogic)
+            .forEach(fieldName => {
+                const currentValue = this.multiStepForm.formData[fieldName];
+                if (currentValue !== undefined) {
+                    this.executeConditionalLogic(fieldName, currentValue);
+                }
+            });
+    }
+    executeConditionalLogic(fieldName, value) {
+        const logic = this.conditionalLogic[fieldName];
+        if (!logic) return;
+        logic.forEach(rule => {
+            const {
+                condition,
+                target,
+                action
+            } = rule;
+            const shouldExecute = this.evaluateCondition(condition, value);
+            if (shouldExecute) {
+                this.executeAction(target, action);
+            }
+        });
+    }
+    evaluateCondition(condition, value) {
+        if (typeof condition === 'function') {
+            return condition(value);
+        }
+        if (typeof condition === 'object') {
+            const {
+                equals,
+                notEquals,
+                includes,
+                notIncludes
+            } = condition;
+            if (equals !== undefined) {
+                return value === equals;
+            }
+            if (notEquals !== undefined) {
+                return value !== notEquals;
+            }
+            if (includes !== undefined) {
+                return Array.isArray(value) ? value.includes(includes) : value === includes;
+            }
+            if (notIncludes !== undefined) {
+                return Array.isArray(value) ? !value.includes(notIncludes) : value !== notIncludes;
+            }
+        }
+        return value === condition;
+    }
+    executeAction(target, action) {
+        const field = this.fieldInstances.find(f => f.name === target);
+        if (!field) return;
+        switch (action.type) {
+        case 'show':
+            field.show();
+            break;
+        case 'hide':
+            field.hide();
+            break;
+        case 'enable':
+            field.enable();
+            break;
+        case 'disable':
+            field.disable();
+            break;
+        case 'setValue':
+            field.setValue(action.value);
+            break;
+        case 'setOptions':
+            if (field.setOptions) {
+                field.setOptions(action.options);
+            }
+            break;
+        }
+    }
+    setActive(active) {
+        this.isActive = active;
+        if (this.container) {
+            this.container.classList.toggle('active', active);
+            this.container.classList.toggle('hidden', !active);
+        }
+    }
+    validate() {
+        let isValid = true;
+        this.fieldInstances.forEach(field => {
+            if (!field.validate()) {
+                isValid = false;
+            }
+        });
+        return isValid;
+    }
+    getStepData() {
+        const data = {};
+        this.fieldInstances.forEach(field => {
+            data[field.name] = field.getValue();
+        });
+        return data;
+    }
+    setStepData(data) {
+        this.fieldInstances.forEach(field => {
+            if (data[field.name] !== undefined) {
+                field.setValue(data[field.name]);
+            }
+        });
+    }
+    reset() {
+        this.fieldInstances.forEach(field => {
+            field.setValue('');
+        });
+    }
+}
+/**
+ * ProgressBar - Progress bar for multi-step forms
+ */
+class ProgressBar {
+    constructor(multiStepForm, config) {
+        this.multiStepForm = multiStepForm;
+        this.config = config;
+        this.totalSteps = config.totalSteps;
+        this.currentStep = config.currentStep || 0;
+        this.showStepNumbers = config.showStepNumbers !== false;
+        this.showStepTitles = config.showStepTitles !== false;
+        this.container = null;
+        this.progressFill = null;
+        this.stepInfo = null;
+    }
+    render() {
+        this.container = document.createElement('div');
+        this.container.className = 'progress-container';
+        const progressBar = document.createElement('div');
+        progressBar.className = 'progress-bar';
+        this.progressFill = document.createElement('div');
+        this.progressFill.className = 'progress-fill';
+        progressBar.appendChild(this.progressFill);
+        this.container.appendChild(progressBar);
+        if (this.showStepNumbers || this.showStepTitles) {
+            this.stepInfo = document.createElement('div');
+            this.stepInfo.className = 'step-info';
+            this.container.appendChild(this.stepInfo);
+        }
+        this.updateProgress(this.currentStep);
+        return this.container;
+    }
+    updateProgress(currentStep) {
+        this.currentStep = currentStep;
+        if (this.progressFill) {
+            const progress = (currentStep / (this.totalSteps - 1)) * 100;
+            this.progressFill.style.width = `${Math.min(progress, 100)}%`;
+        }
+        if (this.stepInfo) {
+            let infoText = '';
+            if (this.showStepNumbers) {
+                infoText += `${this.multiStepForm.factory.getText('step')} ${currentStep + 1} ${this.multiStepForm.factory.getText('of')} ${this.totalSteps}`;
+            }
+            if (this.showStepTitles && this.multiStepForm.steps[currentStep]) {
+                const stepTitle = this.multiStepForm.steps[currentStep].title;
+                if (stepTitle) {
+                    if (infoText) infoText += ' - ';
+                    infoText += stepTitle;
+                }
+            }
+            this.stepInfo.textContent = infoText;
+        }
+    }
+}
+/**
+ * NavigationButtons - Navigation buttons for multi-step forms
+ */
+class NavigationButtons {
+    constructor(multiStepForm) {
+        this.multiStepForm = multiStepForm;
+        this.factory = multiStepForm.factory;
+        this.container = null;
+        this.prevButton = null;
+        this.nextButton = null;
+        this.submitButton = null;
+    }
+    render() {
+        this.container = document.createElement('div');
+        this.container.className = 'form-navigation';
+        this.prevButton = document.createElement('button');
+        this.prevButton.type = 'button';
+        this.prevButton.className = 'btn btn-prev';
+        this.prevButton.textContent = this.factory.getText('previous');
+        this.prevButton.addEventListener('click', () => {
+            this.multiStepForm.previousStep();
+        });
+        this.nextButton = document.createElement('button');
+        this.nextButton.type = 'button';
+        this.nextButton.className = 'btn btn-next';
+        this.nextButton.textContent = this.factory.getText('next');
+        this.nextButton.addEventListener('click', () => {
+            this.multiStepForm.nextStep();
+        });
+        this.submitButton = document.createElement('button');
+        this.submitButton.type = 'button';
+        this.submitButton.className = 'btn btn-submit';
+        this.submitButton.textContent = this.factory.getText('submit');
+        this.submitButton.addEventListener('click', () => {
+            this.multiStepForm.submit();
+        });
+        this.container.appendChild(this.prevButton);
+        this.container.appendChild(this.nextButton);
+        this.container.appendChild(this.submitButton);
+        return this.container;
+    }
+    updateButtons(currentStep, totalSteps) {
+        this.prevButton.style.display = currentStep > 0 ? 'inline-block' : 'none';
+        return this.container;
+    }
+    updateButtons(currentStep, totalSteps) {
+        this.prevButton.style.display = currentStep > 0 ? 'inline-block' : 'none';
+        if (currentStep === totalSteps - 1) {
+            this.nextButton.style.display = 'none';
+            this.submitButton.style.display = 'inline-block';
+        } else {
+            this.nextButton.style.display = 'inline-block';
+            this.submitButton.style.display = 'none';
+        }
+    }
+}
+
+export { MultiStepForm, FormStep, ProgressBar, NavigationButtons };

--- a/src/utils/ValidationUtils.js
+++ b/src/utils/ValidationUtils.js
@@ -1,0 +1,44 @@
+const ValidationUtils = {
+  isValidEmail(email) {
+    const emailPattern = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i;
+    return emailPattern.test(email);
+  },
+  isValidPhoneNumber(phoneNumber) {
+    const phonePattern = /^(\(\d{3}\)|\d{3})[- ]?\d{3}[- ]?\d{4}$/;
+    return phonePattern.test(phoneNumber);
+  },
+  isValidUrl(url) {
+    if (!url || url.trim() === '') return false;
+    let testUrl = url.trim();
+    if (!testUrl.match(/^https?:\/\//)) {
+      testUrl = 'https://' + testUrl;
+    }
+    try {
+      new URL(testUrl);
+      const urlPattern = /^(https?:\/\/)?(www\.)?[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}(\/[a-zA-Z0-9-._~:\/?#[\]@!$&'()*+,;=%]*)?$/;
+      return urlPattern.test(url.trim());
+    } catch (e) {
+      return false;
+    }
+  },
+  formatPhoneNumber(phoneNumber) {
+    const cleaned = phoneNumber.replace(/\D/g, '');
+    if (cleaned.length === 10) {
+      return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(6)}`;
+    }
+    return phoneNumber;
+  },
+  normalizeUrl(url) {
+    if (!url || url.trim() === '') return '';
+    let normalized = url.trim();
+    if (!normalized.match(/^https?:\/\//)) {
+      if (normalized.startsWith('www.') || normalized.split('.').length > 2) {
+        normalized = 'https://' + normalized;
+      } else {
+        normalized = 'https://www.' + normalized;
+      }
+    }
+    return normalized;
+  }
+};
+export default ValidationUtils;


### PR DESCRIPTION
## Summary
- add a `src` tree with modules for fields and forms
- extract BaseField and input field classes
- create separate data modules and utils
- provide a simplified FormFieldFactory that uses the new modules

## Testing
- `npm test` *(fails: package.json missing)*
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6887e16b086483298b2270aa22df06e4